### PR TITLE
Optimise gatsby-node.js in gatsbygram example

### DIFF
--- a/examples/gatsbygram/gatsby-node.js
+++ b/examples/gatsbygram/gatsby-node.js
@@ -1,4 +1,3 @@
-const _ = require(`lodash`)
 const path = require(`path`)
 const slug = require(`slug`)
 const slash = require(`slash`)
@@ -7,7 +6,7 @@ const slash = require(`slash`)
 // called after the Gatsby bootstrap is finished so you have
 // access to any information necessary to programmatically
 // create pages.
-exports.createPages = async ({ graphql, actions }) => {
+exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions
 
   // The “graphql” function allows us to run arbitrary
@@ -35,7 +34,8 @@ exports.createPages = async ({ graphql, actions }) => {
   )
 
   if (result.errors) {
-    throw new Error(result.errors)
+    reporter.panicOnBuild(`Error while running GraphQL query.`)
+    return
   }
 
   // Create image post pages.
@@ -44,7 +44,7 @@ exports.createPages = async ({ graphql, actions }) => {
   // Instagram post. Since the scraped Instagram data
   // already includes an ID field, we just use that for
   // each page's path.
-  _.each(result.data.allPostsJson.edges, edge => {
+  result.data.allPostsJson.edges.forEach(edge => {
     // Gatsby uses Redux to manage its internal state.
     // Plugins and sites can use functions like "createPage"
     // to interact with Gatsby.


### PR DESCRIPTION
The blog post for the case study about it has been updated recently (see #15577) and some improvements were suggested during the code review.

This is to reflect these improvements in the `gatsby-node.js` file in the example code, but basically:

- Use `reporter.panicOnBuild` API in case of errors executing the GraphQL query
- Remove the use of `lodash` and replace it by native `.forEach()`